### PR TITLE
Help xsp find default pages

### DIFF
--- a/src/RedisWebServices.Host/Web.config
+++ b/src/RedisWebServices.Host/Web.config
@@ -16,6 +16,7 @@
     </sectionGroup>
   </configSections>
   <appSettings>
+    <add key="MonoServerDefaultIndexFiles" value="Default.aspx, default.htm" />
     <add key="RedisHostAddress" value="localhost:6379"/>
     <add key="RedisDb" value="0"/>
     <add key="DefaultRedirectPath" value="AjaxClient"/>


### PR DESCRIPTION
Prior to this change, running xsp4 and navigating to 127.0.0.1:8080 would result in a 404. The default.htm page was not automatically found. (I did not test this change on any other server)
