### PR TITLE
Fixed link to services list

### DIFF
--- a/src/RedisWebServices.Host/AjaxClient/default.htm
+++ b/src/RedisWebServices.Host/AjaxClient/default.htm
@@ -79,7 +79,7 @@
                         </ol>
                         <p>
                             This Admin UI is customizable and can be easily modified and made to access any of the
-                            available <a href="../servicestack/metadata">Redis web service operations</a>.
+                            available <a href="../redis/metadata">Redis web service operations</a>.
                         </p>
                         <p>
                             A feature-complete JavaScript <a href="js/RedisClient.js">RedisClient.js</a> library


### PR DESCRIPTION
hosted under /redis (no longer under /servicestack)
